### PR TITLE
Don’t throw an exception for missing assets in prod

### DIFF
--- a/Url/AssetUrl.php
+++ b/Url/AssetUrl.php
@@ -76,8 +76,15 @@ class AssetUrl
             }
             catch (AssetsException $e)
             {
-                // Instead of throwing an exception since we can't resolve the asset, we're returning the
-                // asset path un-altered so the browser will resolve it to a 404
+                // In debug we want to let the developer know that there's a bug due to a missing asset
+                // so we just re-throw the exception.
+                if ($this->isDebug)
+                {
+                    throw $e;
+                }
+
+                // In prod we don't want to potentially bring down the entire since we can't resolve an asset,
+                // so we're returning the asset path un-altered so the browser can resolve it to a 404
                 return $assetPath;
             }
         }

--- a/Url/AssetUrl.php
+++ b/Url/AssetUrl.php
@@ -70,7 +70,16 @@ class AssetUrl
                 ));
             }
 
-            return "{$request->getBaseUrl()}/{$this->registry->get($assetPath)->getOutputFilePath()}";
+            try
+            {
+                return "{$request->getBaseUrl()}/{$this->registry->get($assetPath)->getOutputFilePath()}";
+            }
+            catch (AssetsException $e)
+            {
+                // Instead of throwing an exception since we can't resolve the asset, we're returning the
+                // asset path un-altered so the browser will resolve it to a 404
+                return $assetPath;
+            }
         }
 
         return $this->router->generate("becklyn_assets_embed", [


### PR DESCRIPTION
Instead we’re returning the URL unaltered. We don’t want to bring down the entire site because a single image is missing. Instead the browser should resolve a missing asset path to a 404, if not handled otherwise.

The debug behaviour is unaltered, as in it throws a 404 in the `EmbedController` whenever it can't resolve an asset.