### PR TITLE
Filter out any source maps

### DIFF
--- a/Dependency/DependencyLoader.php
+++ b/Dependency/DependencyLoader.php
@@ -93,13 +93,13 @@ class DependencyLoader
 
         foreach ($dependencyMap as $file => $dependencies)
         {
-            $this->dependencyMap["{$basePath}/{$file}.js"] = \array_map(
-                function (string $file) use ($basePath)
+            foreach ($dependencies as $dependency)
+            {
+                if (\preg_match('~(.*)\.js$~', $dependency))
                 {
-                    return "{$basePath}/{$file}";
-                },
-                $dependencies
-            );
+                    $this->dependencyMap["{$basePath}/{$file}.js"][] = "{$basePath}/{$dependency}";
+                }
+            }
         }
     }
 

--- a/Dependency/DependencyLoader.php
+++ b/Dependency/DependencyLoader.php
@@ -95,7 +95,7 @@ class DependencyLoader
         {
             foreach ($dependencies as $dependency)
             {
-                if (\preg_match('~(.*)\.js$~', $dependency))
+                if ("js" === pathinfo($dependency, PATHINFO_EXTENSION))
                 {
                     $this->dependencyMap["{$basePath}/{$file}.js"][] = "{$basePath}/{$dependency}";
                 }


### PR DESCRIPTION
This filters out source map files that have been included in the `_dependencies.json` file as happened in the latest kaba release, which uses different source maps than previous versions.

The approach used here is simply checking/making sure that the potential asset ends with `.js`.