### PR TITLE
Namespace Registry Freedom + Namespaced Paths in CSS Url Imports

### DIFF
--- a/DependencyInjection/BecklynAssetsConfiguration.php
+++ b/DependencyInjection/BecklynAssetsConfiguration.php
@@ -35,7 +35,7 @@ class BecklynAssetsConfiguration implements ConfigurationInterface
                 ->arrayNode("dependency_maps")
                     ->scalarPrototype()->end()
                     ->defaultValue([])
-                    ->info("The paths to the dependency maps.")
+                    ->info("The paths to the dependency maps. In asset notation: e.g. `@namespace/js/_dependencies.json`")
                 ->end()
             ->end();
 

--- a/File/FileLoader.php
+++ b/File/FileLoader.php
@@ -79,7 +79,7 @@ class FileLoader
             // prepend file header in dev and process in prod
             $fileContent = (self::MODE_PROD === $mode)
                 ? $fileType->processForProd($asset, $fileContent)
-                : $fileType->prependFileHeader($asset, $filePath, $fileContent);
+                : $fileType->processForDev($asset, $filePath, $fileContent);
         }
 
         return $fileContent;

--- a/File/Type/Css/CssUrlImportParser.php
+++ b/File/Type/Css/CssUrlImportParser.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\AssetsBundle\File\Type\Css;
+
+
+class CssUrlImportParser
+{
+    /**
+     * Replaces all valid imports with the result of the $contentReplaceFunction.
+     * The function receives the cleaned path as argument (without the quotes and the function must not add quotes).
+     *
+     * @param string   $fileContent
+     * @param callable $contentReplaceFunction
+     * @return string
+     */
+    public function replaceValidImports (string $fileContent, callable $contentReplaceFunction) : string
+    {
+        return \preg_replace_callback(
+            '~url\\(\s*(?<path>.*?)\s*\\)~i',
+            function (array $matches) use ($contentReplaceFunction)
+            {
+                return $this->ensureValidImportAndReplace($matches, $contentReplaceFunction);
+            },
+            $fileContent
+        );
+    }
+
+
+    /**
+     * Replaces all valid imports with the result of the content replace function
+     *
+     * @param array    $matches
+     * @param callable $contentReplaceFunction
+     * @return string
+     */
+    private function ensureValidImportAndReplace (array $matches, callable $contentReplaceFunction) : string
+    {
+        $path = $matches["path"];
+        $openingQuote = substr($matches["path"], 0, 1);
+        $closingQuote = \substr($matches["path"], -1);
+        $usedQuotes = "";
+
+        // check if quoted and whether valid quoted
+        if ($openingQuote === "'" || $openingQuote === '"')
+        {
+            if ($openingQuote !== $closingQuote)
+            {
+                // looks like invalid CSS, as there is a leading quote, but no closing one, so bail
+                return $matches[0];
+            }
+
+            // strip quotes from path
+            $path = \substr($path, 1, -1);
+            $usedQuotes = $openingQuote;
+        }
+
+        $path = $contentReplaceFunction($path);
+        return "url({$usedQuotes}{$path}{$usedQuotes})";
+    }
+}

--- a/File/Type/CssFile.php
+++ b/File/Type/CssFile.php
@@ -43,6 +43,17 @@ class CssFile extends FileType
     /**
      * @inheritDoc
      */
+    public function processForProd (Asset $asset, string $fileContent) : string
+    {
+        // rewrite namespaced + relative imports in prod
+        $fileContent = $this->importRewriter->rewriteNamespacedImports($fileContent);
+        return $this->importRewriter->rewriteRelativeImports($asset, $fileContent);
+    }
+
+
+    /**
+     * @inheritDoc
+     */
     public function importDeferred () : bool
     {
         // must be loaded deferred, as it might have dependencies on other files
@@ -56,16 +67,5 @@ class CssFile extends FileType
     public function getHtmlLinkFormat () : ?string
     {
         return '<link rel="stylesheet" href="%s"%s>';
-    }
-
-
-    /**
-     * @inheritDoc
-     */
-    public function processForProd (Asset $asset, string $fileContent) : string
-    {
-        // rewrite namespaced + relative imports in prod
-        $fileContent = $this->importRewriter->rewriteNamespacedImports($fileContent);
-        return $this->importRewriter->rewriteRelativeImports($asset, $fileContent);
     }
 }

--- a/File/Type/CssFile.php
+++ b/File/Type/CssFile.php
@@ -61,6 +61,6 @@ class CssFile extends FileType
      */
     public function processForProd (Asset $asset, string $fileContent) : string
     {
-        return $this->importRewriter->rewriteImports($asset, $fileContent);
+        return $this->importRewriter->rewriteStaticImports($asset, $fileContent);
     }
 }

--- a/File/Type/CssFile.php
+++ b/File/Type/CssFile.php
@@ -30,10 +30,13 @@ class CssFile extends FileType
     /**
      * @inheritDoc
      */
-    public function prependFileHeader (Asset $asset, string $filePath, string $fileContent) : string
+    public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
-        $header = $this->generateGenericFileHeader($asset, $filePath, '/*', '*/');
-        return $header . $fileContent;
+        // only rewrite namespaced imports in dev + add file header
+        $fileHeader = $this->generateGenericFileHeader($asset, $filePath, '/*', '*/');
+        $fileContent = $this->importRewriter->rewriteNamespacedImports($fileContent);
+
+        return $fileHeader . $fileContent;
     }
 
 
@@ -61,6 +64,8 @@ class CssFile extends FileType
      */
     public function processForProd (Asset $asset, string $fileContent) : string
     {
-        return $this->importRewriter->rewriteStaticImports($asset, $fileContent);
+        // rewrite namespaced + relative imports in prod
+        $fileContent = $this->importRewriter->rewriteNamespacedImports($fileContent);
+        return $this->importRewriter->rewriteRelativeImports($asset, $fileContent);
     }
 }

--- a/File/Type/FileType.php
+++ b/File/Type/FileType.php
@@ -8,14 +8,14 @@ use Becklyn\AssetsBundle\Asset\Asset;
 abstract class FileType
 {
     /**
-     * Adds the file header
+     * Processes the file content for development
      *
      * @param Asset  $asset
      * @param string $filePath
      * @param string $fileContent
      * @return string
      */
-    public function prependFileHeader (Asset $asset, string $filePath, string $fileContent) : string
+    public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
         return $fileContent;
     }

--- a/File/Type/JavaScriptFile.php
+++ b/File/Type/JavaScriptFile.php
@@ -13,7 +13,7 @@ class JavaScriptFile extends FileType
     /**
      * @inheritDoc
      */
-    public function prependFileHeader (Asset $asset, string $filePath, string $fileContent) : string
+    public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
         $header = $this->generateGenericFileHeader($asset, $filePath, '/*', '*/');
         return $header . $fileContent;

--- a/File/Type/SvgFile.php
+++ b/File/Type/SvgFile.php
@@ -13,7 +13,7 @@ class SvgFile extends FileType
     /**
      * @inheritDoc
      */
-    public function prependFileHeader (Asset $asset, string $filePath, string $fileContent) : string
+    public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
         $header = $this->generateGenericFileHeader($asset, $filePath, '<!--', '-->');
         return $header . $fileContent;

--- a/Namespaces/NamespaceRegistry.php
+++ b/Namespaces/NamespaceRegistry.php
@@ -18,19 +18,11 @@ class NamespaceRegistry implements \IteratorAggregate
 
 
     /**
-     * @var string
+     * @param array<string, string> $namespaces
+     * @throws AssetsException
      */
-    private $projectDir;
-
-
-    /**
-     * @param string $projectDir
-     * @param array  $namespaces
-     */
-    public function __construct (string $projectDir, array $namespaces = [])
+    public function __construct (array $namespaces = [])
     {
-        $this->projectDir = $projectDir;
-
         foreach ($namespaces as $namespace => $directory)
         {
             $this->addNamespace($namespace, $directory);
@@ -42,16 +34,11 @@ class NamespaceRegistry implements \IteratorAggregate
      * Adds a namespace
      *
      * @param string $namespace
-     * @param string $directory
+     * @param string $directory  the absolute path to the assets directory
      * @throws AssetsException
      */
     public function addNamespace (string $namespace, string $directory) : void
     {
-        // prepend directory with project root, if not already there
-        $dir = ($this->projectDir !== substr($directory, 0, strlen($this->projectDir)))
-            ? "{$this->projectDir}/" . trim($directory, "/")
-            : $directory;
-
         if (isset($this->namespaces[$namespace]))
         {
             throw new AssetsException(sprintf(
@@ -60,18 +47,16 @@ class NamespaceRegistry implements \IteratorAggregate
             ));
         }
 
-        if (is_dir($dir))
-        {
-            $this->namespaces[$namespace] = $dir;
-        }
-        else
+        if (!is_dir($directory))
         {
             throw new AssetsException(sprintf(
                 "Can't find assets dir when registering namespace '%s': %s",
                 $namespace,
-                $dir
+                $directory
             ));
         }
+
+        $this->namespaces[$namespace] = $directory;
     }
 
 

--- a/Resources/config/services.yaml
+++ b/Resources/config/services.yaml
@@ -43,8 +43,7 @@ services:
         arguments:
             $isDebug: '%kernel.debug%'
 
-    Becklyn\AssetsBundle\Namespaces\NamespaceRegistry:
-        $projectDir: '%kernel.project_dir%'
+    Becklyn\AssetsBundle\Namespaces\NamespaceRegistry: ~
 
     Becklyn\AssetsBundle\Storage\AssetStorage: ~
     Becklyn\AssetsBundle\Twig\AssetsTwigExtension: ~

--- a/tests/Asset/AssetsRegistryTest.php
+++ b/tests/Asset/AssetsRegistryTest.php
@@ -9,6 +9,7 @@ use Becklyn\AssetsBundle\File\FileTypeRegistry;
 use Becklyn\AssetsBundle\File\Type\GenericFile;
 use Becklyn\AssetsBundle\Storage\AssetStorage;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Tests\Becklyn\AssetsBundle\CreateHashedAssetTrait;
 
 
@@ -26,7 +27,11 @@ class AssetsRegistryTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $registry = new AssetsRegistry($cache, $storage, new FileTypeRegistry(new GenericFile()));
+        $registry = new AssetsRegistry(new ServiceLocator([
+            AssetsCache::class => function () use ($cache) { return $cache; },
+            AssetStorage::class => function () use ($storage) { return $storage; },
+            FileTypeRegistry::class => function () { return new FileTypeRegistry(new GenericFile()); },
+        ]));
         return [$registry, $cache, $storage];
     }
 

--- a/tests/File/FileLoaderTest.php
+++ b/tests/File/FileLoaderTest.php
@@ -33,8 +33,8 @@ class FileLoaderTest extends TestCase
 
     protected function setUp ()
     {
-        $this->namespaceRegistry = new NamespaceRegistry($this->fixtures, [
-            "bundles" => "public/bundles"
+        $this->namespaceRegistry = new NamespaceRegistry([
+            "bundles" => "{$this->fixtures}/public/bundles"
         ]);
 
         $fileTypes = new FileTypeRegistry(new GenericFile());
@@ -97,7 +97,7 @@ class FileLoaderTest extends TestCase
 
         $testFileType
             ->expects(self::once())
-            ->method("prependFileHeader")
+            ->method("processForDev")
             ->willReturnArgument(2);
 
         $fileTypes = new FileTypeRegistry(new GenericFile(), [

--- a/tests/File/Type/Css/CssImportRewriterTest.php
+++ b/tests/File/Type/Css/CssImportRewriterTest.php
@@ -103,7 +103,7 @@ CSS;
 
         self::assertSame(
             $expected,
-            $rewriter->rewriteImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -131,7 +131,7 @@ CSS;
 
         self::assertSame(
             $expected,
-            $rewriter->rewriteImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -156,7 +156,7 @@ CSS;
 
         self::assertSame(
             $input,
-            $rewriter->rewriteImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -179,7 +179,7 @@ CSS;
 
         self::assertSame(
             $input,
-            $rewriter->rewriteImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 }

--- a/tests/File/Type/Css/CssImportRewriterTest.php
+++ b/tests/File/Type/Css/CssImportRewriterTest.php
@@ -5,6 +5,7 @@ namespace Tests\Becklyn\AssetsBundle\File\Type\Css;
 use Becklyn\AssetsBundle\Asset\Asset;
 use Becklyn\AssetsBundle\Asset\AssetsCache;
 use Becklyn\AssetsBundle\File\Type\Css\CssImportRewriter;
+use Becklyn\AssetsBundle\Url\AssetUrl;
 use PHPUnit\Framework\TestCase;
 
 
@@ -36,7 +37,15 @@ class CssImportRewriterTest extends TestCase
                 );
         }
 
-        return new CssImportRewriter($cache);
+        $assetUrl = $this->getMockBuilder(AssetUrl::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $assetUrl
+            ->method("generateUrl")
+            ->willReturn("");
+
+        return new CssImportRewriter($cache, $assetUrl);
     }
 
 
@@ -103,7 +112,7 @@ CSS;
 
         self::assertSame(
             $expected,
-            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteRelativeImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -131,7 +140,7 @@ CSS;
 
         self::assertSame(
             $expected,
-            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteRelativeImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -156,7 +165,7 @@ CSS;
 
         self::assertSame(
             $input,
-            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteRelativeImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 
@@ -179,7 +188,7 @@ CSS;
 
         self::assertSame(
             $input,
-            $rewriter->rewriteStaticImports(new Asset("assets", "css/test.css"), $input)
+            $rewriter->rewriteRelativeImports(new Asset("assets", "css/test.css"), $input)
         );
     }
 }

--- a/tests/Finder/AssetsFinderTest.php
+++ b/tests/Finder/AssetsFinderTest.php
@@ -26,8 +26,8 @@ class AssetsFinderTest extends TestCase
 
     public function testCorrectFindings ()
     {
-        $namespaces = new NamespaceRegistry($this->fixtures, [
-            "bundles" => "bundles",
+        $namespaces = new NamespaceRegistry([
+            "bundles" => "{$this->fixtures}/bundles",
         ]);
 
         $finder = new AssetsFinder($namespaces);

--- a/tests/Html/AssetHtmlGeneratorTest.php
+++ b/tests/Html/AssetHtmlGeneratorTest.php
@@ -58,7 +58,7 @@ class AssetHtmlGeneratorTest extends TestCase
             ->getMock();
 
         $importRewriter
-            ->method("rewriteImports")
+            ->method("rewriteStaticImports")
             ->willReturnArgument(1);
 
         $fileTypeRegistry = new FileTypeRegistry(new GenericFile(), [

--- a/tests/Html/AssetHtmlGeneratorTest.php
+++ b/tests/Html/AssetHtmlGeneratorTest.php
@@ -58,7 +58,7 @@ class AssetHtmlGeneratorTest extends TestCase
             ->getMock();
 
         $importRewriter
-            ->method("rewriteStaticImports")
+            ->method("rewriteRelativeImports")
             ->willReturnArgument(1);
 
         $fileTypeRegistry = new FileTypeRegistry(new GenericFile(), [

--- a/tests/Storage/AssetStorageTest.php
+++ b/tests/Storage/AssetStorageTest.php
@@ -41,9 +41,9 @@ class AssetStorageTest extends TestCase
         $this->fixtures = dirname(__DIR__) . "/fixtures/public";
         $this->outDir = "{$this->fixtures}/out";
 
-        $namespaces = new NamespaceRegistry($this->fixtures, [
-            "bundles" => "bundles",
-            "other" => "other",
+        $namespaces = new NamespaceRegistry([
+            "bundles" => "{$this->fixtures}/bundles",
+            "other" => "{$this->fixtures}/other",
         ]);
 
         $fileTypeRegistry = new FileTypeRegistry(new GenericFile(), [


### PR DESCRIPTION
You can now register namespaces freely with any path.
See commit message in https://github.com/Becklyn/AssetsBundle/commit/5d69cf33002fc4d768cd225d69a9209aaf84047e for details.

Also you can now use namespaced paths in your CSS:

```css
.logo {
    background-image: url("@app/img/logo.svg");
}
```