### PR TITLE
Fix debug comment in SVG files

### DIFF
--- a/File/Type/CssFile.php
+++ b/File/Type/CssFile.php
@@ -33,7 +33,7 @@ class CssFile extends FileType
     public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
         // only rewrite namespaced imports in dev + add file header
-        $fileHeader = $this->generateGenericFileHeader($asset, $filePath, '/*', '*/');
+        $fileHeader = $this->generateGenericFileDebugInfo($asset, $filePath, '/*', '*/');
         $fileContent = $this->importRewriter->rewriteNamespacedImports($fileContent);
 
         return $fileHeader . $fileContent;

--- a/File/Type/GenericFileHeaderTrait.php
+++ b/File/Type/GenericFileHeaderTrait.php
@@ -16,7 +16,7 @@ trait GenericFileHeaderTrait
      * @param string $closingComment
      * @return string
      */
-    private function generateGenericFileHeader (Asset $asset, string $filePath, string $openingComment, string $closingComment) : string
+    private function generateGenericFileDebugInfo (Asset $asset, string $filePath, string $openingComment, string $closingComment) : string
     {
         // keep the blank line at the end, as php strips blank lines at the end of HEREDOC
         return <<<HEADER

--- a/File/Type/JavaScriptFile.php
+++ b/File/Type/JavaScriptFile.php
@@ -15,7 +15,7 @@ class JavaScriptFile extends FileType
      */
     public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
-        $header = $this->generateGenericFileHeader($asset, $filePath, '/*', '*/');
+        $header = $this->generateGenericFileDebugInfo($asset, $filePath, '/*', '*/');
         return $header . $fileContent;
     }
 

--- a/File/Type/SvgFile.php
+++ b/File/Type/SvgFile.php
@@ -15,7 +15,9 @@ class SvgFile extends FileType
      */
     public function processForDev (Asset $asset, string $filePath, string $fileContent) : string
     {
-        $header = $this->generateGenericFileHeader($asset, $filePath, '<!--', '-->');
-        return $header . $fileContent;
+        // the comment must be at the bottom, because if the SVG has a <?xml .. tag, it needs to be the
+        // very first thing in the file and this debug info would be above it.
+        $footer = $this->generateGenericFileDebugInfo($asset, $filePath, '<!--', '-->');
+        return $fileContent . $footer;
     }
 }


### PR DESCRIPTION
The comment must be at the bottom, because if the SVG has a `<?xml .. ?>` tag, it needs to be the very first thing in the file and this debug info would previously be above it.

Also I renamed the method, as it now technically isn't a "header" anymore.