### PR TITLE
Html Builder + Modern Builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 =====
 
 *   Added new debug command: `becklyn:assets:debug`.
+*   Added support for modern + legacy builds for JS. These will only be linked if there are both a `@namespace/file.js` 
+    as well as a `@namespace/_legacy.file.js` entry in the dependency map.
+    These imports + their dependencies will be loaded using either `type="module"` (modern) or `nomodule` (legacy).
 
 2.4.0
 =====

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
+        "becklyn/html-builder": "^2.0",
         "symfony/cache": "^4.2",
         "symfony/config": "^4.2",
         "symfony/console": "^4.2",

--- a/src/Command/Debug/NamespacesPrinter.php
+++ b/src/Command/Debug/NamespacesPrinter.php
@@ -2,7 +2,6 @@
 
 namespace Becklyn\AssetsBundle\Command\Debug;
 
-
 use Becklyn\AssetsBundle\Namespaces\NamespaceRegistry;
 use Symfony\Component\Console\Style\SymfonyStyle;
 

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -47,7 +47,6 @@ class DebugCommand extends Command
 
 
     /**
-     *
      * @param AssetsFinder      $finder
      * @param NamespaceRegistry $namespaceRegistry
      * @param Filesystem        $filesystem
@@ -110,7 +109,7 @@ class DebugCommand extends Command
 
             $rows[$asset->getAssetPath()] = [
                 "<fg=yellow>@{$asset->getNamespace()}</>/{$asset->getFilePath()}",
-                $filePath
+                $filePath,
             ];
         }
 
@@ -118,7 +117,7 @@ class DebugCommand extends Command
 
         $io->table([
             "Asset",
-            "Path"
+            "Path",
         ], $rows);
     }
 

--- a/src/Data/AssetEmbed.php
+++ b/src/Data/AssetEmbed.php
@@ -1,0 +1,100 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\AssetsBundle\Data;
+
+
+use Becklyn\HtmlBuilder\Node\HtmlAttributes;
+
+class AssetEmbed
+{
+    //region Fields
+    /**
+     * @var string
+     */
+    private $assetPath;
+
+
+    /**
+     * @var HtmlAttributes
+     */
+    private $attributes;
+
+
+    /**
+     * @var string|null
+     */
+    private $url;
+    //endregion
+
+
+    /**
+     *
+     * @param string $assetPath
+     * @param array  $attributes
+     */
+    public function __construct (string $assetPath, array $attributes = [])
+    {
+        $this->assetPath = $assetPath;
+        $this->attributes = new HtmlAttributes($attributes);
+    }
+
+
+    //region Accessors
+    /**
+     * @param string $name
+     * @param mixed  $value
+     *
+     * @return self
+     */
+    public function setAttribute (string $name, $value) : self
+    {
+        $this->attributes->set($name, $value);
+        return $this;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getAssetPath () : string
+    {
+        return $this->assetPath;
+    }
+
+
+    /**
+     * @return HtmlAttributes
+     */
+    public function getAttributes () : HtmlAttributes
+    {
+        return $this->attributes;
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function isExternal () : bool
+    {
+        return 0 !== \preg_match('~^(https?:)?//~', $this->assetPath);
+    }
+
+
+    /**
+     * @return string|null
+     */
+    public function getUrl () : ?string
+    {
+        return $this->url;
+    }
+
+
+    /**
+     * @param string|null $url
+     */
+    public function setUrl (?string $url) : void
+    {
+        $this->url = $url;
+    }
+    //endregion
+}

--- a/src/Data/AssetEmbed.php
+++ b/src/Data/AssetEmbed.php
@@ -2,7 +2,6 @@
 
 namespace Becklyn\AssetsBundle\Data;
 
-
 use Becklyn\HtmlBuilder\Node\HtmlAttributes;
 
 class AssetEmbed
@@ -28,7 +27,6 @@ class AssetEmbed
 
 
     /**
-     *
      * @param string $assetPath
      * @param array  $attributes
      */

--- a/src/Dependency/DependencyMap.php
+++ b/src/Dependency/DependencyMap.php
@@ -49,16 +49,15 @@ class DependencyMap
                 {
                     $toLoad = $this->loadForSingleImport($toLoad, $import, ["type" => "module"]);
                     $toLoad = $this->loadForSingleImport($toLoad, $legacy, ["nomodule" => true]);
+                    continue;
                 }
-
-                continue;
             }
 
             // load normally
             $toLoad = $this->loadForSingleImport($toLoad, $import);
         }
 
-        return $toLoad;
+        return \array_values($toLoad);
     }
 
 

--- a/src/Exception/NotEmbeddableFileTypeException.php
+++ b/src/Exception/NotEmbeddableFileTypeException.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\AssetsBundle\Exception;
+
+
+class NotEmbeddableFileTypeException extends AssetsException
+{
+
+}

--- a/src/Exception/NotEmbeddableFileTypeException.php
+++ b/src/Exception/NotEmbeddableFileTypeException.php
@@ -2,8 +2,6 @@
 
 namespace Becklyn\AssetsBundle\Exception;
 
-
 class NotEmbeddableFileTypeException extends AssetsException
 {
-
 }

--- a/src/File/FileTypeRegistry.php
+++ b/src/File/FileTypeRegistry.php
@@ -23,8 +23,8 @@ class FileTypeRegistry
 
 
     /**
-     * @param FileType $genericFileType
-     * @param array    $specializedFileTypes the mapping of `extension => FileType` of all specialized file types
+     * @param GenericFile $genericFileType
+     * @param array       $specializedFileTypes the mapping of `extension => FileType` of all specialized file types
      */
     public function __construct (GenericFile $genericFileType, array $specializedFileTypes = [])
     {

--- a/src/File/Type/CssFile.php
+++ b/src/File/Type/CssFile.php
@@ -3,7 +3,9 @@
 namespace Becklyn\AssetsBundle\File\Type;
 
 use Becklyn\AssetsBundle\Asset\Asset;
+use Becklyn\AssetsBundle\Data\AssetEmbed;
 use Becklyn\AssetsBundle\File\Type\Css\CssImportRewriter;
+use Becklyn\HtmlBuilder\Node\HtmlElement;
 
 class CssFile extends FileType
 {
@@ -61,9 +63,14 @@ class CssFile extends FileType
     /**
      * @inheritDoc
      */
-    public function getHtmlLinkFormat () : ?string
+    public function buildElementForEmbed (AssetEmbed $embed) : HtmlElement
     {
-        return '<link rel="stylesheet" href="%s"%s%s>';
+        return new HtmlElement(
+            "link",
+            $embed->getAttributes()
+                ->set("rel", "stylesheet")
+                ->set("href", $embed->getUrl())
+        );
     }
 
 

--- a/src/File/Type/FileType.php
+++ b/src/File/Type/FileType.php
@@ -4,7 +4,6 @@ namespace Becklyn\AssetsBundle\File\Type;
 
 use Becklyn\AssetsBundle\Asset\Asset;
 use Becklyn\AssetsBundle\Data\AssetEmbed;
-use Becklyn\AssetsBundle\Exception\AssetsException;
 use Becklyn\AssetsBundle\Exception\NotEmbeddableFileTypeException;
 use Becklyn\HtmlBuilder\Node\HtmlElement;
 
@@ -54,6 +53,7 @@ abstract class FileType
      * Returns the element for embedding this file type.
      *
      * @throws NotEmbeddableFileTypeException
+     *
      * @return HtmlElement
      */
     public function buildElementForEmbed (AssetEmbed $embed) : HtmlElement

--- a/src/File/Type/FileType.php
+++ b/src/File/Type/FileType.php
@@ -3,6 +3,10 @@
 namespace Becklyn\AssetsBundle\File\Type;
 
 use Becklyn\AssetsBundle\Asset\Asset;
+use Becklyn\AssetsBundle\Data\AssetEmbed;
+use Becklyn\AssetsBundle\Exception\AssetsException;
+use Becklyn\AssetsBundle\Exception\NotEmbeddableFileTypeException;
+use Becklyn\HtmlBuilder\Node\HtmlElement;
 
 abstract class FileType
 {
@@ -47,17 +51,14 @@ abstract class FileType
 
 
     /**
-     * Returns the link format to link to this file type from HTML.
+     * Returns the element for embedding this file type.
      *
-     * Is passed to sprintf() with the following parameters:
-     *      1: the url
-     *      2: integrity HTML attribute
-     *
-     * @return string|null
+     * @throws NotEmbeddableFileTypeException
+     * @return HtmlElement
      */
-    public function getHtmlLinkFormat () : ?string
+    public function buildElementForEmbed (AssetEmbed $embed) : HtmlElement
     {
-        return null;
+        throw new NotEmbeddableFileTypeException();
     }
 
 

--- a/src/File/Type/JavaScriptFile.php
+++ b/src/File/Type/JavaScriptFile.php
@@ -3,6 +3,8 @@
 namespace Becklyn\AssetsBundle\File\Type;
 
 use Becklyn\AssetsBundle\Asset\Asset;
+use Becklyn\AssetsBundle\Data\AssetEmbed;
+use Becklyn\HtmlBuilder\Node\HtmlElement;
 
 class JavaScriptFile extends FileType
 {
@@ -22,9 +24,14 @@ class JavaScriptFile extends FileType
     /**
      * @inheritDoc
      */
-    public function getHtmlLinkFormat () : ?string
+    public function buildElementForEmbed (AssetEmbed $embed) : HtmlElement
     {
-        return '<script defer src="%s"%s%s></script>';
+        return new HtmlElement(
+            "script",
+            $embed->getAttributes()
+                ->set("defer", true)
+                ->set("src", $embed->getUrl())
+        );
     }
 
 

--- a/src/Html/AssetHtmlGenerator.php
+++ b/src/Html/AssetHtmlGenerator.php
@@ -46,6 +46,12 @@ class AssetHtmlGenerator
 
 
     /**
+     * @var HtmlBuilder
+     */
+    private $htmlBuilder;
+
+
+    /**
      * @param AssetsRegistry       $registry
      * @param AssetUrl             $assetUrl
      * @param FileTypeRegistry     $fileTypeRegistry

--- a/src/Html/AssetHtmlGenerator.php
+++ b/src/Html/AssetHtmlGenerator.php
@@ -101,12 +101,18 @@ class AssetHtmlGenerator
 
                 if (null !== $fragment)
                 {
-                    $embed->setUrl(\str_replace("#{$fragment}", "", $embed));
+                    $embed->setUrl(\str_replace("#{$fragment}", "", $embed->getAssetPath()));
                     \parse_str($fragment, $urlParameters);
 
-                    $embed
-                        ->setAttribute("integrity", $urlParameters["integrity"] ?? null)
-                        ->setAttribute("crossorigin", $urlParameters["crossorigin"] ?? null);
+                    foreach (["integrity", "crossorigin"] as $param)
+                    {
+                        $value = \trim($urlParameters[$param] ?? "");
+
+                        if ("" !== $value)
+                        {
+                            $embed->setAttribute($param, $value);
+                        }
+                    }
 
                     if (isset($urlParameters["type"]))
                     {

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -8,7 +8,7 @@ services:
 
     Becklyn\AssetsBundle\:
         resource: '../../*'
-        exclude: '../../{Asset/Asset.php,DependencyInjection,Exception,Resources,BecklynAssetsBundle.php}'
+        exclude: '../../{Asset/Asset.php,Data,DependencyInjection,Exception,Resources,BecklynAssetsBundle.php}'
 
     Becklyn\AssetsBundle\Controller\EmbedController:
         public: true

--- a/tests/Dependency/DependencyMapTest.php
+++ b/tests/Dependency/DependencyMapTest.php
@@ -2,6 +2,7 @@
 
 namespace Becklyn\AssetsBundle\tests\Dependency;
 
+use Becklyn\AssetsBundle\Data\AssetEmbed;
 use Becklyn\AssetsBundle\Dependency\DependencyMap;
 use PHPUnit\Framework\TestCase;
 
@@ -19,8 +20,8 @@ class DependencyMapTest extends TestCase
     protected function setUp () : void
     {
         $this->map = new DependencyMap([
-            "a" => [1, 2, "a-dep"],
-            "b" => [1, "b-dep"],
+            "a" => ["1", "2", "a-dep"],
+            "b" => ["1", "b-dep"],
         ]);
     }
 
@@ -31,7 +32,7 @@ class DependencyMapTest extends TestCase
     public function testUniqueAndCorrectOrder () : void
     {
         $load = $this->map->getImportsWithDependencies(["a", "b"]);
-        self::assertSame([1, 2, "a-dep", "b-dep"], $load);
+        $this->assertAssetEmbedOrder(["1", "2", "a-dep", "b-dep"], $load);
     }
 
 
@@ -41,6 +42,24 @@ class DependencyMapTest extends TestCase
     public function testMissing () : void
     {
         $load = $this->map->getImportsWithDependencies(["a", "c", "b"]);
-        self::assertSame([1, 2, "a-dep", "c", "b-dep"], $load);
+        $this->assertAssetEmbedOrder(["1", "2", "a-dep", "c", "b-dep"], $load);
+    }
+
+
+    /**
+     * @param array $expected
+     * @param array $embeds
+     */
+    private function assertAssetEmbedOrder (array $expected, array $embeds)
+    {
+        $prepared = \array_map(
+            function (AssetEmbed $embed)
+            {
+                return $embed->getAssetPath();
+            },
+            $embeds
+        );
+
+        self::assertSame($expected, $prepared);
     }
 }

--- a/tests/File/FileLoaderTest.php
+++ b/tests/File/FileLoaderTest.php
@@ -167,7 +167,7 @@ class FileLoaderTest extends TestCase
             ->expects(self::never())
             ->method("processForProd");
 
-        $genericFileType = $this->getMockBuilder(FileType::class)
+        $genericFileType = $this->getMockBuilder(GenericFile::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Html/AssetHtmlGeneratorTest.php
+++ b/tests/Html/AssetHtmlGeneratorTest.php
@@ -251,19 +251,19 @@ class AssetHtmlGeneratorTest extends TestCase
                 [
                     "http://example.org/test#type=css&integrity=abc",
                 ],
-                '<link rel="stylesheet" href="http://example.org/test" integrity="abc">',
+                '<link integrity="abc" rel="stylesheet" href="http://example.org/test">',
             ],
             "CSS file with explicit defined type and integrirty and crossorigin" => [
                 [
                     "http://example.org/test#type=css&integrity=abc&crossorigin=anonymous",
                 ],
-                '<link rel="stylesheet" href="http://example.org/test" integrity="abc" crossorigin="anonymous">',
+                '<link integrity="abc" crossorigin="anonymous" rel="stylesheet" href="http://example.org/test">',
             ],
             "JS file with crossorigin" => [
                 [
                     "http://example.org/test.js#crossorigin=use-credentials",
                 ],
-                '<script defer src="http://example.org/test.js" crossorigin="use-credentials"></script>',
+                '<script crossorigin="use-credentials" defer src="http://example.org/test.js"></script>',
             ],
             "JS file with explicit defined type and an empty integrity, which will be ignored" => [
                 [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | —

<!-- describe your changes below -->
We now use `becklyn/html-builder` internally.

Also this patch adds support for legacy + modern builds.
These will only be loaded if for a JS asset there are both the `file.js` entry as well as `_legacy.file.js` entry in the dependency map.