### PR TITLE
Add support for new modern builds + fix bug in duplicate dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.6.0
+=====
+
+*   Added support for the new `_modern.entry.js` + `entry.js` builds (this is the new way Kaba builds the entries, the old way is `_legacy.entry.js` + `entry.js`).
+*   Fixed a bug where a dependency that was both required in legacy + modern builds was only loaded once for one of the entries.
+
 2.5.0
 =====
 

--- a/src/Dependency/Dependency/AssetDependency.php
+++ b/src/Dependency/Dependency/AssetDependency.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\AssetsBundle\Dependency\Dependency;
+
+use Becklyn\AssetsBundle\Data\AssetEmbed;
+
+class AssetDependency
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var bool
+     */
+    private $modern = false;
+
+    /**
+     * @var bool
+     */
+    private $legacy = false;
+
+
+    /**
+     * @param string $name
+     */
+    public function __construct (string $name)
+    {
+        $this->name = $name;
+    }
+
+
+    /**
+     *
+     */
+    public function setModern () : void
+    {
+        $this->modern = true;
+    }
+
+
+    /**
+     *
+     */
+    public function setLegacy () : void
+    {
+        $this->legacy = true;
+    }
+
+
+    /**
+     * @return AssetEmbed
+     */
+    public function getAssetEmbed () : AssetEmbed
+    {
+        $attributes = [];
+
+        if ($this->modern && !$this->legacy)
+        {
+            $attributes = ["type" => "module"];
+        }
+        elseif (!$this->modern && $this->legacy)
+        {
+            $attributes = ["nomodule" => true];
+        }
+
+        return new AssetEmbed($this->name, $attributes);
+    }
+}

--- a/src/Dependency/DependencyMap.php
+++ b/src/Dependency/DependencyMap.php
@@ -3,11 +3,16 @@
 namespace Becklyn\AssetsBundle\Dependency;
 
 use Becklyn\AssetsBundle\Data\AssetEmbed;
+use Becklyn\AssetsBundle\Dependency\Dependency\AssetDependency;
 
 class DependencyMap
 {
+    private const MODERN = true;
+    private const LEGACY = false;
+    private const NEUTRAL = null;
+
     /**
-     * @var array
+     * @var string[][]
      */
     private $map = [];
 
@@ -34,6 +39,7 @@ class DependencyMap
      */
     public function getImportsWithDependencies (array $imports) : array
     {
+        /** @var AssetDependency[] $toLoad */
         $toLoad = [];
 
         foreach ($imports as $import)
@@ -41,32 +47,54 @@ class DependencyMap
             $dirname = \dirname($import);
             $basename = \basename($import);
 
+            $dirname = ("." === $dirname)
+                ? ""
+                : "{$dirname}/";
+
             if ("js" === \pathinfo($basename, \PATHINFO_EXTENSION))
             {
-                $legacy = "{$dirname}/_legacy.{$basename}";
+                $legacy = "{$dirname}_legacy.{$basename}";
+                $modern = "{$dirname}_modern.{$basename}";
 
+                // load legacy Kaba builds: `entry` + `_legacy.entry`
                 if (\array_key_exists($import, $this->map) && \array_key_exists($legacy, $this->map))
                 {
-                    $toLoad = $this->loadForSingleImport($toLoad, $import, ["type" => "module"]);
-                    $toLoad = $this->loadForSingleImport($toLoad, $legacy, ["nomodule" => true]);
+                    $toLoad = $this->loadForSingleImport($toLoad, $import, self::MODERN);
+                    $toLoad = $this->loadForSingleImport($toLoad, $legacy, self::LEGACY);
+                    continue;
+                }
+
+                // load modern Kaba builds: `entry` + `_modern.entry`
+                if (\array_key_exists($import, $this->map) && \array_key_exists($modern, $this->map))
+                {
+                    $toLoad = $this->loadForSingleImport($toLoad, $import, self::LEGACY);
+                    $toLoad = $this->loadForSingleImport($toLoad, $modern, self::MODERN);
                     continue;
                 }
             }
 
             // load normally
-            $toLoad = $this->loadForSingleImport($toLoad, $import);
+            $toLoad = $this->loadForSingleImport($toLoad, $import, self::NEUTRAL);
         }
 
-        return \array_values($toLoad);
+        return \array_map(
+            function (AssetDependency $dependency)
+            {
+                return $dependency->getAssetEmbed();
+            },
+            $toLoad
+        );
     }
 
 
     /**
-     * @param string $import
+     * @param AssetDependency[] $allImports
+     * @param string            $import
+     * @param bool|null         $modernOrLegacy
      *
-     * @return AssetEmbed[]
+     * @return AssetDependency[]
      */
-    private function loadForSingleImport (array $allImports, string $import, array $embedAttributes = []) : array
+    private function loadForSingleImport (array $allImports, string $import, ?bool $modernOrLegacy) : array
     {
         $dependencies = $this->map[$import] ?? null;
 
@@ -75,14 +103,43 @@ class DependencyMap
         {
             foreach ($dependencies as $dependency)
             {
-                $allImports[$dependency] = new AssetEmbed($dependency, $embedAttributes);
+                $allImports = $this->createDependency($dependency, $allImports, $modernOrLegacy);
             }
         }
         else
         {
-            $allImports[$import] = new AssetEmbed($import, $embedAttributes);
+            $allImports = $this->createDependency($import, $allImports, $modernOrLegacy);
         }
 
         return $allImports;
+    }
+
+
+    /**
+     * @param string            $name
+     * @param AssetDependency[] $map
+     * @param bool|null         $modernOrLegacy
+     *
+     * @return AssetDependency[]
+     */
+    private function createDependency (string $name, array $map, ?bool $modernOrLegacy) : array
+    {
+        if (!\array_key_exists($name, $map))
+        {
+            $map[$name] = new AssetDependency($name);
+        }
+
+        $dependency = $map[$name];
+
+        if (self::MODERN === $modernOrLegacy)
+        {
+            $dependency->setModern();
+        }
+        elseif (self::LEGACY === $modernOrLegacy)
+        {
+            $dependency->setLegacy();
+        }
+
+        return $map;
     }
 }

--- a/src/Dependency/DependencyMap.php
+++ b/src/Dependency/DependencyMap.php
@@ -7,9 +7,9 @@ use Becklyn\AssetsBundle\Dependency\Dependency\AssetDependency;
 
 class DependencyMap
 {
-    private const MODERN = true;
-    private const LEGACY = false;
-    private const NEUTRAL = null;
+    private const NEUTRAL = 0;
+    private const MODERN = 1;
+    private const LEGACY = 2;
 
     /**
      * @var string[][]
@@ -90,11 +90,11 @@ class DependencyMap
     /**
      * @param AssetDependency[] $allImports
      * @param string            $import
-     * @param bool|null         $modernOrLegacy
+     * @param int               $modernOrLegacy
      *
      * @return AssetDependency[]
      */
-    private function loadForSingleImport (array $allImports, string $import, ?bool $modernOrLegacy) : array
+    private function loadForSingleImport (array $allImports, string $import, int $modernOrLegacy) : array
     {
         $dependencies = $this->map[$import] ?? null;
 
@@ -118,11 +118,11 @@ class DependencyMap
     /**
      * @param string            $name
      * @param AssetDependency[] $map
-     * @param bool|null         $modernOrLegacy
+     * @param int               $modernOrLegacy
      *
      * @return AssetDependency[]
      */
-    private function createDependency (string $name, array $map, ?bool $modernOrLegacy) : array
+    private function createDependency (string $name, array $map, int $modernOrLegacy) : array
     {
         if (!\array_key_exists($name, $map))
         {

--- a/src/Namespaces/NamespaceRegistry.php
+++ b/src/Namespaces/NamespaceRegistry.php
@@ -64,7 +64,7 @@ class NamespaceRegistry implements \IteratorAggregate
             return;
         }
 
-        $this->namespaces[$namespace] = $directory;
+        $this->namespaces[$namespace] = \rtrim($directory, "/");
     }
 
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| New feature?  | yes <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | **missing** <!-- insert URL here -->

<!-- describe your changes below -->
*   Added support for the new `_modern.entry.js` + `entry.js` builds (this is the new way Kaba builds the entries, the old way is `_legacy.entry.js` + `entry.js`).
*   Fixed a bug where a dependency that was both required in legacy + modern builds was only loaded once for one of the entries.