### PR TITLE
Allow older versions of Symfony/Mime to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+2.6.3
+=====
+
+*   Allow older versions of `Symfony/Mime` to be used with this lib. This re-establishes usage in Symfony 4.x projects again, as they most likely restricted the version
+    of Symfony components to 4.x.
+
+
 2.6.2
 =====
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/filesystem": "^4.2 || ^5.0",
         "symfony/finder": "^4.2 || ^5.0",
         "symfony/http-kernel": "^4.2 || ^5.0",
-        "symfony/mime": "^5.0",
+        "symfony/mime": "^4.3 || ^5.0",
         "symfony/process": "^4.2 || ^5.0",
         "symfony/routing": "^4.2 || ^5.0",
         "symfony/service-contracts": "^1.1 || ^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Improvement?  |no <!-- improves an existing feature, not adding a new one --> 
| New feature?  |no <!-- don't forget to update CHANGELOG.md -->
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | **missing** <!-- insert URL here -->

Unfortunately we have to at least require v4.3 as there is no older version of it available. This should be still sufficient enough to support a wider range of apps as we're now still back into the 4.x area, as most 4.x restrictions will now allow to install this version of the AssetsBundle again.

I'm not sure whether how much effort we should invest into making it Symfony 4.2 compatible. For that specific version, we might need a compatibility layer - like we did in `becklyn/hosting` with the two asset libs. Tbh I'd probably at least require all libs to be Symfony ^4.3 with Symfony ^5.0 in our own v3.x but I'm open for discussions.